### PR TITLE
Removed browser dependency

### DIFF
--- a/search_google.py
+++ b/search_google.py
@@ -64,7 +64,7 @@ class SearchHandler(idaapi.action_handler_t):
         idaapi.action_handler_t.__init__(self)
         
     def activate(self, ctx):
-        os.system("START chrome http://www.google.com/search?q=\"" + highlight[0] + "\"")
+        os.system("START http://www.google.com/search?q=\"" + highlight[0] + "\"")
         
         return 1
         


### PR DESCRIPTION
Since using "chrome" in the command line makes the script dependent on the existent of `chrome.exe`, in the system in general and in the `PATH` specifically, it's not a best-practice.

Alternatively, omitting _"chrome"_ from the command to be executed by `os.system()` will use the default browser of the system.